### PR TITLE
Fix rollover persistence and sync today date

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -55,7 +55,9 @@ export default function RootLayout() {
         const today = getToday(useSettingsStore.getState().dayStart);
         processRollover(today).then(() => {
           // Simply refresh data - the query filtering will handle the rest
-          useAppStore.getState().refreshData();
+          const appState = useAppStore.getState();
+          appState.syncTodayDate();
+          appState.refreshData();
         });
       }
     });

--- a/lib/logic/rollover.ts
+++ b/lib/logic/rollover.ts
@@ -93,6 +93,10 @@ export async function processRollover(nowLocalDate: string) {
     ? lastProcessedDateStr
     : nowLocalDate;
 
+  if (!lastProcessedDateStr) {
+    await storage.setItem("last_processed_date", lastProcessedDate);
+  }
+
   console.log(`Processing rollover from ${lastProcessedDate} to ${nowLocalDate}`);
 
   while (
@@ -125,8 +129,5 @@ export async function processRollover(nowLocalDate: string) {
     await storage.setItem("last_processed_date", lastProcessedDate);
   }
 
-  // If we're on a new day, ensure we have a clean slate
-  if (fromLocalDate(lastProcessedDate).isBefore(fromLocalDate(nowLocalDate))) {
-    await storage.setItem("last_processed_date", nowLocalDate);
-  }
+  await storage.setItem("last_processed_date", lastProcessedDate);
 }

--- a/lib/stores/appStore.ts
+++ b/lib/stores/appStore.ts
@@ -12,6 +12,7 @@ type HabitCompletion = repo.HabitCompletion;
 interface AppState {
   isInitialized: boolean;
   todayDate: string;
+  syncTodayDate: () => string;
 
   // Data for "Today" screen
   todayTasks: Task[];
@@ -66,6 +67,14 @@ interface AppState {
 export const useAppStore = create<AppState>((set, get) => ({
   isInitialized: false,
   todayDate: getToday(useSettingsStore.getState().dayStart),
+  syncTodayDate: () => {
+    const computedToday = getToday(useSettingsStore.getState().dayStart);
+    const currentToday = get().todayDate;
+    if (currentToday !== computedToday) {
+      set({ todayDate: computedToday });
+    }
+    return computedToday;
+  },
   todayTasks: [],
   activeHabits: [],
   todaysHabitCompletions: [],
@@ -73,14 +82,13 @@ export const useAppStore = create<AppState>((set, get) => ({
   overdueTasks: [],
 
   init: async () => {
-    const dayStart = useSettingsStore.getState().dayStart;
-    const today = getToday(dayStart);
+    const today = get().syncTodayDate();
     set({ todayDate: today, isInitialized: true });
     await get().refreshData();
   },
 
   refreshData: async () => {
-    const today = get().todayDate;
+    const today = get().syncTodayDate();
     const [todayTasks, activeHabits, completions, slateTasks, overdueTasks] =
       await Promise.all([
         repo.listTodayTasks(today),
@@ -133,7 +141,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   planTaskForToday: async (taskId) => {
-    await repo.planTaskFor(taskId, get().todayDate);
+    const today = get().syncTodayDate();
+    await repo.planTaskFor(taskId, today);
     await get().refreshData();
   },
 
@@ -143,7 +152,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   skipTaskForToday: async (taskId) => {
-    const tomorrow = addDays(get().todayDate, 1);
+    const tomorrow = addDays(get().syncTodayDate(), 1);
     await repo.skipTaskForToday(taskId, tomorrow);
     await get().refreshData();
   },
@@ -159,12 +168,14 @@ export const useAppStore = create<AppState>((set, get) => ({
   },
 
   completeHabit: async (habitId) => {
-    await repo.completeHabitToday(habitId, get().todayDate);
+    const today = get().syncTodayDate();
+    await repo.completeHabitToday(habitId, today);
     await get().refreshData();
   },
 
   undoHabit: async (habitId) => {
-    await repo.undoHabitToday(habitId, get().todayDate);
+    const today = get().syncTodayDate();
+    await repo.undoHabitToday(habitId, today);
     await get().refreshData();
   },
 
@@ -178,3 +189,14 @@ export const useAppStore = create<AppState>((set, get) => ({
     await get().refreshData();
   },
 }));
+
+useSettingsStore.subscribe(
+  (state) => state.dayStart,
+  () => {
+    const appState = useAppStore.getState();
+    appState.syncTodayDate();
+    if (appState.isInitialized) {
+      appState.refreshData();
+    }
+  }
+);

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "ios": "expo start --ios",
     "web": "expo start --web",
     "lint": "expo lint",
+    "test": "node scripts/run-tests.js",
     "update": "eas update --platform ios --branch main"
   },
   "dependencies": {

--- a/scripts/run-tests.js
+++ b/scripts/run-tests.js
@@ -1,0 +1,70 @@
+const fs = require("fs");
+const path = require("path");
+const Module = require("module");
+const ts = require("typescript");
+
+const projectRoot = path.resolve(__dirname, "..");
+
+const mocks = new Map([
+  ["expo-sqlite/kv-store", path.join(projectRoot, "tests/mocks/kv-store.ts")],
+  ["expo-crypto", path.join(projectRoot, "tests/mocks/expo-crypto.ts")],
+  ["@/lib/db/connection", path.join(projectRoot, "tests/mocks/db-connection.ts")],
+  ["@/lib/logic/repo", path.join(projectRoot, "tests/mocks/repo.ts")],
+  ["@/lib/logic/dates", path.join(projectRoot, "tests/mocks/dates.ts")],
+]);
+
+const originalResolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, parent, isMain, options) {
+  if (mocks.has(request)) {
+    const mockedPath = mocks.get(request);
+    return originalResolveFilename.call(this, mockedPath, parent, isMain, options);
+  }
+  if (request.startsWith("@/")) {
+    const resolved = path.join(projectRoot, request.slice(2));
+    return originalResolveFilename.call(this, resolved, parent, isMain, options);
+  }
+  return originalResolveFilename.call(this, request, parent, isMain, options);
+};
+
+require.extensions[".ts"] = function (module, filename) {
+  const source = fs.readFileSync(filename, "utf8");
+  const { outputText } = ts.transpileModule(source, {
+    compilerOptions: {
+      module: ts.ModuleKind.CommonJS,
+      target: ts.ScriptTarget.ES2019,
+      jsx: ts.JsxEmit.React,
+      esModuleInterop: true,
+    },
+    fileName: filename,
+  });
+  module._compile(outputText, filename);
+};
+
+async function runTest(file) {
+  const mod = require(file);
+  if (typeof mod.run !== "function") {
+    throw new Error(`Test file ${file} must export a run() function`);
+  }
+  await mod.run();
+}
+
+(async () => {
+  const testsDir = path.join(projectRoot, "tests");
+  if (!fs.existsSync(testsDir)) {
+    console.log("No tests directory found. Skipping.");
+    return;
+  }
+  const entries = fs
+    .readdirSync(testsDir)
+    .filter((file) => file.endsWith(".test.ts"))
+    .sort();
+  for (const file of entries) {
+    const fullPath = path.join(testsDir, file);
+    console.log(`Running ${file}...`);
+    await runTest(fullPath);
+  }
+  console.log("All tests passed.");
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/appStore.test.ts
+++ b/tests/appStore.test.ts
@@ -1,0 +1,101 @@
+import assert from "assert";
+
+import { useAppStore } from "@/lib/stores/appStore";
+import { useSettingsStore } from "@/lib/stores/settings";
+import { state as repoState } from "@/lib/logic/repo";
+import { addDays, getToday, setMockToday } from "@/lib/logic/dates";
+
+function resetRepoState() {
+  repoState.todayTasks = [];
+  repoState.activeHabits = [];
+  repoState.completions = [];
+  repoState.slateTasks = [];
+  repoState.overdueTasks = [];
+  repoState.planTaskForCalls.length = 0;
+  repoState.skipTaskForTodayCalls.length = 0;
+  repoState.completeHabitTodayCalls.length = 0;
+  repoState.undoHabitTodayCalls.length = 0;
+  delete repoState.lastListTodayDate;
+  delete repoState.lastCompletionsDate;
+  delete repoState.lastOverdueDate;
+}
+
+function resetStores(initialDay: string) {
+  resetRepoState();
+  setMockToday(initialDay);
+  useSettingsStore.setState({ dayStart: "04:00", loading: false });
+  useAppStore.setState({
+    isInitialized: false,
+    todayDate: getToday("04:00"),
+    todayTasks: [],
+    activeHabits: [],
+    todaysHabitCompletions: [],
+    slateTasks: [],
+    overdueTasks: [],
+  });
+}
+
+export async function run() {
+  await testRefreshDataRecomputesToday();
+  await testPlanTaskUsesUpdatedToday();
+  await testSkipTaskUsesTomorrow();
+  await testHabitActionsUseUpdatedToday();
+}
+
+async function testRefreshDataRecomputesToday() {
+  resetStores("2024-06-01");
+  await useAppStore.getState().refreshData();
+  assert.strictEqual(repoState.lastListTodayDate, "2024-06-01");
+  assert.strictEqual(repoState.lastCompletionsDate, "2024-06-01");
+  assert.strictEqual(repoState.lastOverdueDate, "2024-06-01");
+  assert.strictEqual(useAppStore.getState().todayDate, "2024-06-01");
+
+  setMockToday("2024-06-02");
+  await useAppStore.getState().refreshData();
+  assert.strictEqual(repoState.lastListTodayDate, "2024-06-02");
+  assert.strictEqual(repoState.lastCompletionsDate, "2024-06-02");
+  assert.strictEqual(repoState.lastOverdueDate, "2024-06-02");
+  assert.strictEqual(useAppStore.getState().todayDate, "2024-06-02");
+}
+
+async function testPlanTaskUsesUpdatedToday() {
+  resetStores("2024-07-01");
+  await useAppStore.getState().planTaskForToday("task-1");
+  assert.deepStrictEqual(repoState.planTaskForCalls, [
+    { id: "task-1", date: "2024-07-01" },
+  ]);
+
+  setMockToday("2024-07-02");
+  await useAppStore.getState().planTaskForToday("task-2");
+  assert.deepStrictEqual(repoState.planTaskForCalls, [
+    { id: "task-1", date: "2024-07-01" },
+    { id: "task-2", date: "2024-07-02" },
+  ]);
+}
+
+async function testSkipTaskUsesTomorrow() {
+  resetStores("2024-08-10");
+  await useAppStore.getState().skipTaskForToday("task-3");
+  assert.deepStrictEqual(repoState.skipTaskForTodayCalls, [
+    { id: "task-3", date: addDays("2024-08-10", 1) },
+  ]);
+}
+
+async function testHabitActionsUseUpdatedToday() {
+  resetStores("2024-09-15");
+  await useAppStore.getState().completeHabit("habit-1");
+  await useAppStore.getState().undoHabit("habit-1");
+  assert.deepStrictEqual(repoState.completeHabitTodayCalls, [
+    { id: "habit-1", date: "2024-09-15" },
+  ]);
+  assert.deepStrictEqual(repoState.undoHabitTodayCalls, [
+    { id: "habit-1", date: "2024-09-15" },
+  ]);
+
+  setMockToday("2024-09-16");
+  await useAppStore.getState().completeHabit("habit-2");
+  assert.deepStrictEqual(repoState.completeHabitTodayCalls, [
+    { id: "habit-1", date: "2024-09-15" },
+    { id: "habit-2", date: "2024-09-16" },
+  ]);
+}

--- a/tests/mocks/dates.ts
+++ b/tests/mocks/dates.ts
@@ -1,0 +1,77 @@
+import dayjs from "dayjs";
+import timezone from "dayjs/plugin/timezone";
+import utc from "dayjs/plugin/utc";
+
+dayjs.extend(utc);
+dayjs.extend(timezone);
+
+let forcedToday: string | null = null;
+
+export const setMockToday = (date: string | null) => {
+  forcedToday = date;
+};
+
+export const nowISO = (): string => dayjs().toISOString();
+
+export const toLocalDate = (date: Date | dayjs.Dayjs | string): string =>
+  dayjs(date).format("YYYY-MM-DD");
+
+export const fromLocalDate = (dateStr: string): dayjs.Dayjs => dayjs(dateStr);
+
+export const addDays = (date: string, days: number): string =>
+  dayjs(date).add(days, "day").format("YYYY-MM-DD");
+
+export const getToday = (dayStartHHmm: string): string => {
+  if (forcedToday) {
+    return forcedToday;
+  }
+  const now = dayjs();
+  const [hour, minute] = dayStartHHmm.split(":").map(Number);
+  const dayStartTime = now.hour(hour).minute(minute).second(0).millisecond(0);
+
+  if (now.isBefore(dayStartTime)) {
+    return now.subtract(1, "day").format("YYYY-MM-DD");
+  }
+  return now.format("YYYY-MM-DD");
+};
+
+export const getSixMonthsAgo = (): string => {
+  return dayjs().subtract(6, "month").format("YYYY-MM-DD");
+};
+
+export const getCurrentMonth = (): string => {
+  return dayjs().format("YYYY-MM");
+};
+
+export const isDateInRange = (
+  date: string,
+  minDate: string,
+  maxDate: string
+): boolean => {
+  const dateObj = dayjs(date);
+  const minObj = dayjs(minDate);
+  const maxObj = dayjs(maxDate);
+  return dateObj.isAfter(minObj) || dateObj.isSame(minObj, "day");
+};
+
+export const isDateBefore = (date1: string, date2: string): boolean => {
+  return dayjs(date1).isBefore(dayjs(date2), "day");
+};
+
+export const isDateAfter = (date1: string, date2: string): boolean => {
+  return dayjs(date1).isAfter(dayjs(date2), "day");
+};
+
+export const isDateSameOrBefore = (date1: string, date2: string): boolean => {
+  return (
+    dayjs(date1).isSame(dayjs(date2), "day") ||
+    dayjs(date1).isBefore(dayjs(date2), "day")
+  );
+};
+
+export const isDateSameOrAfter = (date1: string, date2: string): boolean => {
+  return (
+    dayjs(date1).isSame(dayjs(date2), "day") ||
+    dayjs(date1).isAfter(dayjs(date2), "day")
+  );
+};

--- a/tests/mocks/db-connection.ts
+++ b/tests/mocks/db-connection.ts
@@ -1,0 +1,77 @@
+import Database from "better-sqlite3";
+import { drizzle } from "drizzle-orm/better-sqlite3";
+import * as schema from "@/lib/db/schema";
+
+const sqlite = new Database(":memory:");
+
+const createSchema = () => {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS tasks (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      notes TEXT,
+      due_date TEXT,
+      scheduled_for TEXT,
+      completed_at TEXT,
+      depends_on_task_id TEXT,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL,
+      status TEXT NOT NULL DEFAULT 'open'
+    );
+
+    CREATE TABLE IF NOT EXISTS habits (
+      id TEXT PRIMARY KEY,
+      title TEXT NOT NULL,
+      notes TEXT,
+      is_active INTEGER NOT NULL DEFAULT 1,
+      created_at TEXT NOT NULL,
+      updated_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS habit_completions (
+      id TEXT PRIMARY KEY,
+      habit_id TEXT NOT NULL,
+      date TEXT NOT NULL,
+      completed_at TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS habit_history (
+      id TEXT PRIMARY KEY,
+      date TEXT NOT NULL,
+      habit_id TEXT NOT NULL,
+      completed INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS task_history (
+      id TEXT PRIMARY KEY,
+      date TEXT NOT NULL,
+      task_id TEXT NOT NULL,
+      planned INTEGER NOT NULL,
+      completed INTEGER NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS app_settings (
+      key TEXT PRIMARY KEY,
+      value TEXT NOT NULL
+    );
+  `);
+};
+
+createSchema();
+
+export const db = drizzle(sqlite, { schema });
+
+export const initializeDatabase = async () => {
+  createSchema();
+};
+
+export const resetDatabase = () => {
+  sqlite.exec(`
+    DELETE FROM habit_history;
+    DELETE FROM habit_completions;
+    DELETE FROM task_history;
+    DELETE FROM tasks;
+    DELETE FROM habits;
+    DELETE FROM app_settings;
+  `);
+};

--- a/tests/mocks/expo-crypto.ts
+++ b/tests/mocks/expo-crypto.ts
@@ -1,0 +1,3 @@
+import { randomUUID as nodeRandomUUID } from "crypto";
+
+export const randomUUID = () => nodeRandomUUID();

--- a/tests/mocks/kv-store.ts
+++ b/tests/mocks/kv-store.ts
@@ -1,0 +1,19 @@
+const store = new Map<string, string>();
+
+export default {
+  async getItem(key: string): Promise<string | null> {
+    return store.has(key) ? store.get(key)! : null;
+  },
+  async setItem(key: string, value: string): Promise<void> {
+    store.set(key, value);
+  },
+  async removeItem(key: string): Promise<void> {
+    store.delete(key);
+  },
+};
+
+export const resetStorage = () => {
+  store.clear();
+};
+
+export const dumpStorage = () => new Map(store);

--- a/tests/mocks/repo.ts
+++ b/tests/mocks/repo.ts
@@ -1,0 +1,56 @@
+export const state = {
+  todayTasks: [] as unknown[],
+  activeHabits: [] as unknown[],
+  completions: [] as unknown[],
+  slateTasks: [] as unknown[],
+  overdueTasks: [] as unknown[],
+  planTaskForCalls: [] as { id: string; date: string | null }[],
+  skipTaskForTodayCalls: [] as { id: string; date: string }[],
+  completeHabitTodayCalls: [] as { id: string; date: string }[],
+  undoHabitTodayCalls: [] as { id: string; date: string }[],
+};
+
+export const listTodayTasks = async (date: string) => {
+  state.lastListTodayDate = date;
+  return state.todayTasks;
+};
+
+export const listActiveHabits = async () => state.activeHabits;
+
+export const getHabitCompletionsForDate = async (date: string) => {
+  state.lastCompletionsDate = date;
+  return state.completions;
+};
+
+export const listAllTasks = async () => state.slateTasks;
+export const listOverdueTasks = async (date: string) => {
+  state.lastOverdueDate = date;
+  return state.overdueTasks;
+};
+
+export const planTaskFor = async (id: string, date: string | null) => {
+  state.planTaskForCalls.push({ id, date });
+};
+
+export const skipTaskForToday = async (id: string, date: string) => {
+  state.skipTaskForTodayCalls.push({ id, date });
+};
+
+export const completeHabitToday = async (habitId: string, date: string) => {
+  state.completeHabitTodayCalls.push({ id: habitId, date });
+};
+
+export const undoHabitToday = async (habitId: string, date: string) => {
+  state.undoHabitTodayCalls.push({ id: habitId, date });
+};
+
+export const createTask = async () => {};
+export const createHabit = async () => {};
+export const updateTask = async () => {};
+export const updateHabit = async () => {};
+export const getTaskById = () => undefined;
+export const getHabitById = () => undefined;
+export const completeTask = async () => {};
+export const undoCompleteTask = async () => {};
+export const deleteTask = async () => {};
+export const deleteHabit = async () => {};

--- a/tests/rollover.test.ts
+++ b/tests/rollover.test.ts
@@ -1,0 +1,95 @@
+import assert from "assert";
+import { eq } from "drizzle-orm";
+
+import { resetDatabase } from "@/lib/db/connection";
+import { habitHistory, taskHistory, tasks } from "@/lib/db/schema";
+import { processRollover, storage } from "@/lib/logic/rollover";
+import { addDays } from "@/lib/logic/dates";
+import { randomUUID } from "expo-crypto";
+import { db } from "@/lib/db/connection";
+import { resetStorage } from "expo-sqlite/kv-store";
+
+export async function run() {
+  await testInitialPersistence();
+  await testCarryOverOpenTasks();
+}
+
+async function testInitialPersistence() {
+  resetStorage();
+  resetDatabase();
+
+  const today = "2024-02-01";
+  await processRollover(today);
+
+  const persisted = await storage.getItem("last_processed_date");
+  assert.strictEqual(
+    persisted,
+    today,
+    "processRollover should persist the current date when storage is empty"
+  );
+}
+
+async function testCarryOverOpenTasks() {
+  resetStorage();
+  resetDatabase();
+
+  const dayOne = "2024-03-10";
+  const dayTwo = addDays(dayOne, 1);
+
+  const taskId = randomUUID();
+  await db.insert(tasks).values({
+    id: taskId,
+    title: "Carry me",
+    notes: null,
+    dueDate: null,
+    scheduledFor: dayOne,
+    completedAt: null,
+    dependsOnTaskId: null,
+    createdAt: `${dayOne}T08:00:00.000Z`,
+    updatedAt: `${dayOne}T08:00:00.000Z`,
+    status: "open",
+  });
+
+  await storage.setItem("last_processed_date", dayOne);
+
+  await processRollover(dayTwo);
+
+  const updatedTask = await db
+    .select()
+    .from(tasks)
+    .where(eq(tasks.id, taskId))
+    .get();
+  assert(updatedTask, "task should still exist after rollover");
+  assert.strictEqual(
+    updatedTask.scheduledFor,
+    dayTwo,
+    "open tasks should be rescheduled to the following day"
+  );
+
+  const historyRows = await db
+    .select()
+    .from(taskHistory)
+    .where(eq(taskHistory.taskId, taskId));
+  assert.strictEqual(
+    historyRows.length,
+    1,
+    "rollover should create a single task history row for the finalized day"
+  );
+  assert.strictEqual(historyRows[0].date, dayOne);
+  assert.strictEqual(historyRows[0].planned, true);
+  assert.strictEqual(historyRows[0].completed, false);
+
+  const habitRows = await db.select().from(habitHistory);
+  assert.strictEqual(
+    habitRows.length,
+    0,
+    "no habit history rows should be created when no habits exist"
+  );
+
+  const persisted = await storage.getItem("last_processed_date");
+  assert.strictEqual(
+    persisted,
+    dayTwo,
+    "rollover should persist the final processed date"
+  );
+}


### PR DESCRIPTION
## Summary
- persist the rollover checkpoint even on first launch and keep storage in sync after processing days
- recompute the app store's todayDate before date-sensitive actions and refreshes, and sync when returning to the foreground or changing settings
- add a lightweight Node-based test harness with regression coverage for rollover carry-over and today-date updates

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_69025111b94c83298eb13bdaa0b87360